### PR TITLE
Specify text format

### DIFF
--- a/ElaboracionMemoriaTFG.tex
+++ b/ElaboracionMemoriaTFG.tex
@@ -2,7 +2,9 @@
 \usepackage[a4paper]{geometry}
 \usepackage{xcolor}
 \usepackage{color}
-\usepackage[spanish]{babel}
+\usepackage[main=spanish]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage{hyperref}
 \usepackage{booktabs}
@@ -19,7 +21,6 @@
 \setlist[todolist]{label=$\square$}
 \usepackage{color}
 \usepackage{rotating}
-%\usepackage[utf8]{inputenc}
 \usepackage{charter} % Palatino como fuente principal
 \usepackage{emptypage} % Evita encabezados y pies de página en páginas vacías
 \usepackage{microtype}


### PR DESCRIPTION
Specify utf8 format to make conversion to other types different from pdf such as mobi,epub for eBooks work properly.

Previously, when converting from PDF to MOBI/ePUB etc the accentuation of the characters wouldn't be on top of the character but on the side.

With this change, the PDF converter (I have used Calibre) knows how to handle the characters correctly.